### PR TITLE
Actions were being disabled after deleting a card

### DIFF
--- a/js/s.js
+++ b/js/s.js
@@ -97,6 +97,7 @@ var HTML_CARD = "<section class=card><div class=text>",
         d: function ($card) {
             if (confirm("Are you sure you want to delete this card?")) {
                 $card.fadeOut(function () {
+                    $actions.detach();
                     $card.remove();
                     save();
                 });


### PR DESCRIPTION
I added a line to detach the actions from a card before removing it. Something weird seemed to happen with the delegation of the click event on occasion. Detaching the actions menu seems to help.
